### PR TITLE
docs(api): add more documentation

### DIFF
--- a/api/src/controller/previewController.ts
+++ b/api/src/controller/previewController.ts
@@ -1,15 +1,21 @@
-import { Body, Controller, Delete, Get, Path, Post, Response, Route, SuccessResponse } from 'tsoa';
+import { Body, Controller, Delete, Get, Path, Post, Route, SuccessResponse } from 'tsoa';
 
 import { Preview } from '../previews/previews';
 import { PreviewCreationParams, PreviewService } from '../previews/previewService';
 import { app, log } from '../app';
 import { Request as ExRequest, Response as ExResponse } from 'express';
 
+/**
+ * The main control class for the `/previews` route.
+ */
 @Route('previews')
 export class PreviewsController extends Controller {
+    /**
+     * Create a preview.
+     * @param requestBody The body needed to make this request. Specifically the author ID and content.
+     */
     @Post()
     @SuccessResponse('201', 'Created')
-    @Response('500', 'authorID is not a BigInt')
     public async createPreview(
         @Body() requestBody: PreviewCreationParams
     ): Promise<Preview> {
@@ -22,6 +28,11 @@ export class PreviewsController extends Controller {
         return created as Preview
     }
 
+    /**
+     * Delete a preview.
+     * @param id The ID of the preview.
+     * @param authorID The author ID of the preview.
+     */
     @Delete('{id}')
     @SuccessResponse(204, 'Deleted')
     public async deletePreview(
@@ -32,6 +43,10 @@ export class PreviewsController extends Controller {
         return await new PreviewService().delete(id, authorID)
     }
 
+    /**
+     * Gets all the previews for the specific user.
+     * @param authorID The specific author to get previews from.
+     */
     @Get('{authorID}')
     public async getAll(
         @Path() authorID: string

--- a/api/src/previews/previewService.ts
+++ b/api/src/previews/previewService.ts
@@ -2,9 +2,17 @@ import { randomUUID } from 'crypto';
 import { prisma } from '../app';
 import { Preview } from './previews';
 
-export type PreviewCreationParams = Pick<Preview, 'authorID' | 'content'>
+/**
+ * The parameters required to creating a preview. This includes `authorID` and `content`.
+ */
+export interface PreviewCreationParams extends Pick<Preview, 'authorID' | 'content'> {}
 
 export class PreviewService {
+    /**
+     * A function that creates a preview in the database.
+     * @param data The creation data to add.
+     * @returns {Promise<Preview>} The new preview.
+     */
     public async create(data: PreviewCreationParams): Promise<Preview> {
         return await prisma.preview.create({
             data: {
@@ -18,6 +26,12 @@ export class PreviewService {
         }) as Preview
     }
 
+    /**
+     * A function that deletes a preview in the database.
+     * @param id The ID of the preview.
+     * @param authorID The author of the preview's user ID.
+     * @returns {null} null
+     */
     public async delete(id: string, authorID: string): Promise<null> {
         return await prisma.preview.delete({
             where: {
@@ -27,6 +41,11 @@ export class PreviewService {
         }) as null
     }
 
+    /**
+     *
+     * @param authorID The ID of the user of which's previews to get.
+     * @returns {Array<Preview>} The list of previews, if any. Returns an empty array if empty.
+     */
     public async getAll(authorID: string): Promise<Array<Preview>> {
         return await prisma.preview.findMany({
             where: {

--- a/api/src/previews/previews.ts
+++ b/api/src/previews/previews.ts
@@ -1,5 +1,13 @@
+/**
+ * The preview model/object containing all the data in a preview.
+ */
 export interface Preview {
+    /** The ID of the preview. This cannot be modified/added by the user. */
     id: string;
+    /** The author of this preview. */
     authorID: string;
+    /**
+     * The preview's content. This contains the Meta/OG tags.
+     */
     content: string;
 }


### PR DESCRIPTION
This closes #1 by adding more documentation to everything in the API. This includes documenting the routes, the internal functions for database management, and the models as well.

**NOTE**: The responses are not documented as much, as there are not that many helpful errors, which will be done in a seperate PR for #8